### PR TITLE
Fix Riverpod usage and theme property

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -26,9 +26,11 @@ class TechStoreApp extends ConsumerWidget {
       GoRoute(path: '/admin', builder: (_, __) => const AdminPanel()),
     ],
     redirect: (context, state) {
-      final isLoggedIn = context.read(authProvider).isLoggedIn;
-      final isAdmin = context.read(authProvider).isAdmin;
-      if (state.subloc == '/admin' && (!isLoggedIn || !isAdmin)) {
+      final container = ProviderScope.containerOf(context, listen: false);
+      final auth = container.read(authProvider);
+      final isLoggedIn = auth.isLoggedIn;
+      final isAdmin = auth.isAdmin;
+      if (state.uri.path == '/admin' && (!isLoggedIn || !isAdmin)) {
         return '/';
       }
       return null;

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -3,5 +3,5 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'app.dart';
 
 void main() {
-  runApp(const ProviderScope(child: TechStoreApp()));
+  runApp(ProviderScope(child: TechStoreApp()));
 }

--- a/lib/screens/product_detail_screen.dart
+++ b/lib/screens/product_detail_screen.dart
@@ -20,7 +20,7 @@ class ProductDetailScreen extends ConsumerWidget {
             children: [
               Image.network(product.imageUrl, height: 200),
               const SizedBox(height: 8),
-              Text(product.name, style: Theme.of(context).textTheme.headline6),
+              Text(product.name, style: Theme.of(context).textTheme.titleLarge),
               Text('\$'+product.price.toStringAsFixed(2)),
               const SizedBox(height: 8),
               Text(product.description),


### PR DESCRIPTION
## Summary
- update `GoRouter` auth redirect logic to work with Riverpod 2
- remove const from `ProviderScope` and modernize theme usage
- replace deprecated `headline6` with `titleLarge`

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68868b1cb6d883219c233811699b6650