### PR TITLE
Integrate Fake Store and Stripe APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,17 @@ This repository contains a simplified Flutter application that demonstrates the 
 - **GoRouter** based navigation
 - **Riverpod** for state management
 - Basic authentication distinguishing normal users and admins
-- Placeholder API service using the `http` package
+- API integration with the [Fake Store API](https://fakestoreapi.com)
+- Payment processing using the [Stripe API](https://stripe.com/docs/api)
 - Separate screens for catalog, product details, cart, payment and administration
 
 The app is not fully functional but serves as a starting point for further development.
+
+## Configuration
+
+Set the `STRIPE_SECRET_KEY` compile-time variable when building the app to enable Stripe payments:
+
+```bash
+flutter run --dart-define=STRIPE_SECRET_KEY=<your_secret_key>
+```
+

--- a/lib/models/product.dart
+++ b/lib/models/product.dart
@@ -5,12 +5,19 @@ class Product {
   final double price;
   final String description;
 
-  Product({required this.id, required this.name, required this.imageUrl, required this.price, required this.description});
+  Product({
+    required this.id,
+    required this.name,
+    required this.imageUrl,
+    required this.price,
+    required this.description,
+  });
 
+  /// Parses a product returned from the Fake Store API.
   factory Product.fromJson(Map<String, dynamic> json) => Product(
         id: json['id'].toString(),
-        name: json['name'],
-        imageUrl: json['imageUrl'],
+        name: json['title'] ?? json['name'],
+        imageUrl: json['image'] ?? json['imageUrl'],
         price: (json['price'] as num).toDouble(),
         description: json['description'] ?? '',
       );


### PR DESCRIPTION
## Summary
- hook up product catalogue to the Fake Store API
- implement simple Stripe payment intent creation
- document API usage and Stripe configuration in README

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68868e015c2883219309543e68a4c5b8