### PR TITLE
Filter Fake Store API to electronics

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ This repository contains a simplified Flutter application that demonstrates the 
 - **Riverpod** for state management
 - Basic authentication distinguishing normal users and admins
 - API integration with the [Fake Store API](https://fakestoreapi.com)
+- Product catalog limited to the `electronics` category for relevancy
 - Payment processing using the [Stripe API](https://stripe.com/docs/api)
 - Separate screens for catalog, product details, cart, payment and administration
 

--- a/lib/services/api_service.dart
+++ b/lib/services/api_service.dart
@@ -7,11 +7,14 @@ class ApiService {
   final http.Client _client = http.Client();
   // Base URL for products from the Fake Store API
   final String productBaseUrl = 'https://fakestoreapi.com/products';
+  // Endpoint scoped to the electronics category
+  final String electronicsUrl =
+      'https://fakestoreapi.com/products/category/electronics';
   // Stripe payment endpoint
   final String paymentBaseUrl = 'https://api.stripe.com/v1/payment_intents';
 
   Future<List<Product>> fetchProducts() async {
-    final res = await _client.get(Uri.parse(productBaseUrl));
+    final res = await _client.get(Uri.parse(electronicsUrl));
     if (res.statusCode != 200) {
       throw Exception('Failed to fetch products: ${res.statusCode}');
     }


### PR DESCRIPTION
## Summary
- restrict product fetches to electronics category so the sample store displays relevant items
- note electronics-only catalog in README

## Testing
- `apt-get update`
- `apt-get install -y flutter` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_68869228a94083219374f4a80d0b8dc4